### PR TITLE
Add optional attendees tests and implementation

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -49,7 +49,7 @@ public final class FindMeetingQuery {
 
     // Edge case: No mandatory attendees or at least one available time slot for all attendees.
     if (mandatoryAttendees.isEmpty() || !allAttendeesAvailableTimes.isEmpty()) {
-        return allAttendeesAvailableTimes;
+      return allAttendeesAvailableTimes;
     }
 
     // Edge case: Meeting duration exceeds a whole day.

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -39,6 +39,11 @@ public final class FindMeetingQuery {
    * Worst-case runtime: O(events * attendees).
   */
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
+    // Edge case: Meeting duration exceeds a whole day.
+    if (request.getDuration() > TimeRange.WHOLE_DAY.duration()) {
+      return Arrays.asList();
+    }
+
     Collection<String> mandatoryAttendees = request.getAttendees();
     Collection<String> allAttendees = new ArrayList<String>();
     allAttendees.addAll(mandatoryAttendees);
@@ -50,11 +55,6 @@ public final class FindMeetingQuery {
     // Edge case: No mandatory attendees or at least one available time slot for all attendees.
     if (mandatoryAttendees.isEmpty() || !allAttendeesAvailableTimes.isEmpty()) {
       return allAttendeesAvailableTimes;
-    }
-
-    // Edge case: Meeting duration exceeds a whole day.
-    if (request.getDuration() > TimeRange.WHOLE_DAY.duration()) {
-      return Arrays.asList();
     }
 
     // Create a busy schedule and use it to create a list of available times.

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -34,6 +34,7 @@ public final class FindMeetingQueryTest {
   // Some people that we can use in our tests.
   private static final String PERSON_A = "Person A";
   private static final String PERSON_B = "Person B";
+  private static final String PERSON_C = "Person C";
 
   // All dates are the first day of the year 2020.
   private static final int TIME_0800AM = TimeRange.getTimeInMinutes(8, 0);
@@ -268,6 +269,148 @@ public final class FindMeetingQueryTest {
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected = Arrays.asList();
 
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void optionalAttendeeIsBusy() {
+    // Have each person have different events. We should see three options because each person has
+    // split the restricted times and C (optional attendee) is not invited since it's busy all day.
+    //
+    // Events  :       |--A--|     |--B--|
+    //           |--------------C--------------|
+    // Day     : |-----------------------------|
+    // Options : |--1--|     |--2--|     |--3--|
+ 
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event("Event 3", TimeRange.fromStartDuration(TimeRange.START_OF_DAY, TimeRange.END_OF_DAY),
+            Arrays.asList(PERSON_C)));
+ 
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    
+    request.addOptionalAttendee(PERSON_C);
+ 
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+ 
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void optionalAttendeeCanAttend() {
+    // Have each person have different events. We should see two options because each person has
+    // split the restricted times.
+    //
+    // Events  :       |--A--||--C--||--B--|
+    // Day     : |-------------------------------|
+    // Options : |--1--|                   |--3--|
+ 
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event("Event 3", TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_C)));
+ 
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    
+    request.addOptionalAttendee(PERSON_C);
+ 
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+ 
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void ignoreOptionalAttendee() {
+    // Have one person, but make it so that there is just enough room at one point in the day to
+    // have the meeting. Optional attendee B should be ignored since considering their
+    // schedule would result in no time slot exists.
+    //
+    // Events  : |--A--||--B--||----A----|
+    // Day     : |---------------------|
+    // Options :       |-----|
+ 
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 3", TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, true),
+            Arrays.asList(PERSON_B)));
+ 
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
+ 
+    request.addOptionalAttendee(PERSON_B);
+ 
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
+ 
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void onlyOptionalAttendeesWithGaps() {
+    // No mandatory attendees, just two optional attendees with several gaps
+    // in their schedules. those gaps should be identified and returned.
+ 
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_1000AM, DURATION_60_MINUTES),
+            Arrays.asList(PERSON_B)));
+ 
+    MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_30_MINUTES);
+ 
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
+ 
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+            TimeRange.fromStartEnd(TIME_0900AM, TIME_1000AM, false),
+            TimeRange.fromStartEnd(TIME_1100AM, TimeRange.END_OF_DAY, true));
+ 
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void onlyOptionalAttendeesWithNoGaps() {
+    // No mandatory attendees, just two optional attendees with no gaps in their schedules. 
+    // Query should return that no time is available.
+    //
+    // Events  : |---A--||------B------|
+    // Day     : |---------------------|
+    // Options : 
+ 
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0830AM, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_B)));
+ 
+    MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_30_MINUTES);
+ 
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
+ 
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected = Arrays.asList();
+ 
     Assert.assertEquals(expected, actual);
   }
 }

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -341,7 +341,7 @@ public final class FindMeetingQueryTest {
     // schedule would result in no time slot exists.
     //
     // Events  : |--A--||--B--||----A----|
-    // Day     : |---------------------|
+    // Day     : |-----------------------|
     // Options :       |-----|
  
     Collection<Event> events = Arrays.asList(


### PR DESCRIPTION
There are 5 new scenarios from the walkthroughs to add to FindMeetingQueryTest.java. 

Implement the query that includes optional attendees' tests.
The basic functionality of optional attendees is that if one or more time slots exists so that both mandatory and optional attendees can attend, return those time slots. Otherwise, return the time slots that fit just the mandatory attendees.